### PR TITLE
Fix ReferenceError and/or TypeError in browser with webpack 5

### DIFF
--- a/dist/CookieStorage.js
+++ b/dist/CookieStorage.js
@@ -21,10 +21,6 @@ var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
 
 var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
 
-var _promise = require('babel-runtime/core-js/promise');
-
-var _promise2 = _interopRequireDefault(_promise);
-
 var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
 
 var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
@@ -33,9 +29,9 @@ var _createClass2 = require('babel-runtime/helpers/createClass');
 
 var _createClass3 = _interopRequireDefault(_createClass2);
 
-var _setImmediate2 = require('babel-runtime/core-js/set-immediate');
+var _promise = require('babel-runtime/core-js/promise');
 
-var _setImmediate3 = _interopRequireDefault(_setImmediate2);
+var _promise2 = _interopRequireDefault(_promise);
 
 var _cookiesJs = require('cookies-js');
 
@@ -43,8 +39,9 @@ var _cookiesJs2 = _interopRequireDefault(_cookiesJs);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var genericSetImmediate = typeof _setImmediate3.default === 'undefined' ? global.setImmediate : _setImmediate3.default;
-var nextTick = process && process.nextTick ? process.nextTick : genericSetImmediate;
+var nextTick = function nextTick(f) {
+  return _promise2.default.resolve().then(f);
+};
 
 var CookieStorage = exports.CookieStorage = function () {
   function CookieStorage() {

--- a/src/CookieStorage.js
+++ b/src/CookieStorage.js
@@ -1,7 +1,6 @@
 import Cookies from 'cookies-js'
 
-const genericSetImmediate = typeof setImmediate === 'undefined' ? global.setImmediate : setImmediate
-const nextTick = process && process.nextTick ? process.nextTick : genericSetImmediate
+const nextTick = f => Promise.resolve().then(f)
 
 export class CookieStorage {
 


### PR DESCRIPTION
When building with webpack 5 and run in a browser, redux-persist-async-cookie-storage fails with:
```txt
Uncaught ReferenceError: process is not defined
```

webpack 5 doesn't polyfill node's `process` API, and the test for the presence of `process` doesn't work because referencing a non-existent global variable throws `ReferenceError`.

On browsers that don't provide `setImmediate`, the reference to `global.setImmediate` would fail for the same reason.

Also, `setImmediate` is non-standard, and [no modern browser supports it](https://caniuse.com/setimmediate). So when building with webpack 5, neither `process.nextTick` nor `setImmediate` is available in modern browsers.

This PR fixes the problem by replacing `nextTick` with an implementation that uses Promises instead. This implementation is exactly equivalent to `setImmediate`, and has no special requirements since redux-persist-async-cookie-storage already uses Promises.